### PR TITLE
End to end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run: cd data_models && python setup.py sdist
       - run: ./common/run_tests.sh
       - run: cd common && python setup.py sdist
+      - run: ./run_rabbitmq.sh
       - run: ./foreman/run_tests.sh
       - run: chmod -R a+rw workers/test_volume
       - run: ./workers/run_tests.sh

--- a/data_models/install.sh
+++ b/data_models/install.sh
@@ -27,6 +27,6 @@ iptables -A INPUT -s 172.17.0.0/16 -j ACCEPT
 # See http://stackoverflow.com/questions/31249112/allow-docker-container-to-connect-to-a-local-host-postgres-database
 # and https://blog.jsinh.in/how-to-enable-remote-access-to-postgresql-database-server/#.WNFiBCErLmG
 # for more information on these two settings.
-echo 'host    all             all             172.17.0.0/16           md5' >> /etc/postgresql/$POST_GRES_VERSION/main/pg_hba.conf
+echo 'host    all             all             172.17.0.0/16           md5' >> /etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf
 
 sed -i "s/#\(listen_addresses\)\( = 'localhost'\)/\1 = '*'/" /etc/postgresql/$POSTGRES_VESRION/main/postgresql.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - rabbitmq
     links:
       - rabbitmq:rabbit
-    env_file: workers/environments/dev
+    env_file: workers/environments/test
   foreman:
     build:
       context: .
@@ -28,5 +28,6 @@ services:
       - workers
     links:
       - rabbitmq:rabbit
-    env_file: foreman/environments/dev
-    command: "survey $EXPERIMENT_LIST"
+    env_file: foreman/environments/test
+    command: test --keepdb --no-input data_refinery_foreman.surveyor.end_to_end_tests
+    # command: "survey $EXPERIMENT_LIST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  rabbitmq:
+  message-queue:
     image: "rabbitmq:3"
   workers:
     build:
@@ -11,9 +11,9 @@ services:
     extra_hosts:
       - "database:$HOST_IP"
     depends_on:
-      - rabbitmq
+      - message-queue
     links:
-      - rabbitmq:rabbit
+      - message-queue:rabbit
     env_file: workers/environments/test
   foreman:
     build:
@@ -24,10 +24,10 @@ services:
     extra_hosts:
       - "database:$HOST_IP"
     depends_on:
-      - rabbitmq
+      - message-queue
       - workers
     links:
-      - rabbitmq:rabbit
+      - message-queue:rabbit
     env_file: foreman/environments/test
     command: test --keepdb --no-input data_refinery_foreman.surveyor.end_to_end_tests
     # command: "survey $EXPERIMENT_LIST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,13 @@ version: '3'
 services:
   message-queue:
     image: "rabbitmq:3"
+  nginx:
+    image: nginx
+    volumes:
+      - "$STATIC_DIRECTORY:/usr/share/nginx/html:ro"
+    ports:
+      - "80:80"
+      - "21:21"
   workers:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  rabbitmq:
+    image: "rabbitmq:3"
+  workers:
+    build:
+      context: .
+      dockerfile: workers/Dockerfile
+    volumes:
+      - "$VOLUME_DIRECTORY:/home/user/data_store"
+    extra_hosts:
+      - "database:$HOST_IP"
+    depends_on:
+      - rabbitmq
+    links:
+      - rabbitmq:rabbit
+    env_file: workers/environments/dev
+  foreman:
+    build:
+      context: .
+      dockerfile: foreman/Dockerfile
+    volumes:
+      - "$VOLUME_DIRECTORY:/home/user/data_store"
+    extra_hosts:
+      - "database:$HOST_IP"
+    depends_on:
+      - rabbitmq
+      - workers
+    links:
+      - rabbitmq:rabbit
+    env_file: foreman/environments/dev
+    command: "survey $EXPERIMENT_LIST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - "$STATIC_DIRECTORY:/usr/share/nginx/html:ro"
     ports:
       - "80:80"
-      - "21:21"
   workers:
     build:
       context: .

--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -149,7 +149,7 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
 
         return batches
 
-    def survey(self):
+    def survey(self) -> bool:
         experiment_accession_code = (
             SurveyJobKeyValue
             .objects
@@ -174,4 +174,9 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
         download_urls = {batch.download_url for batch in batches}
         for url in download_urls:
             batches_with_url = [batch for batch in batches if batch.download_url == url]
-            self.handle_batches(batches_with_url)
+            try:
+                self.handle_batches(batches_with_url)
+            except Exception:
+                return False
+
+        return True

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -1,6 +1,9 @@
 import time
+import json
 from django.test import TransactionTestCase
+from unittest.mock import patch, Mock
 from data_refinery_models.models import (
+    Organism,
     SurveyJob,
     SurveyJobKeyValue,
     Batch,
@@ -8,6 +11,7 @@ from data_refinery_models.models import (
     ProcessorJob
 )
 from data_refinery_foreman.surveyor import surveyor
+from data_refinery_foreman.surveyor.array_express import EXPERIMENTS_URL
 
 # Import and set logger
 import logging
@@ -16,6 +20,228 @@ logger = logging.getLogger(__name__)
 
 
 LOOP_TIME = 5  # seconds
+
+EXPERIMENTS_JSON = """
+{
+  "experiments": {
+    "experiment": [
+      {
+        "bioassaydatagroup": [
+          {
+            "isderived": 0,
+            "bioassays": 1,
+            "dataformat": "rawData",
+            "arraydesignprovider": null,
+            "bioassaydatacubes": 1,
+            "name": "rawData",
+            "id": null
+          },
+          {
+            "isderived": 0,
+            "bioassays": 1,
+            "dataformat": "scan",
+            "arraydesignprovider": null,
+            "bioassaydatacubes": 1,
+            "name": "scan",
+            "id": null
+          },
+          {
+            "isderived": 1,
+            "bioassays": 1,
+            "dataformat": "processedDataMatrix",
+            "arraydesignprovider": null,
+            "bioassaydatacubes": 1,
+            "name": "processedDataMatrix",
+            "id": null
+          }
+        ],
+        "protocol": [
+          {
+            "accession": "P-GSE22166-6",
+            "id": 52818
+          },
+          {
+            "accession": "P-GSE22166-8",
+            "id": 52820
+          },
+          {
+            "accession": "P-GSE22166-5",
+            "id": 52814
+          },
+          {
+            "accession": "P-GSE22166-7",
+            "id": 52819
+          },
+          {
+            "accession": "P-GSE22166-4",
+            "id": 52815
+          },
+          {
+            "accession": "P-GSE22166-3",
+            "id": 52816
+          },
+          {
+            "accession": "P-GSE22166-2",
+            "id": 52817
+          },
+          {
+            "accession": "P-GSE22166-1",
+            "id": 52813
+          }
+        ],
+        "arraydesign": [
+          {
+            "legacy_id": 405156763,
+            "count": 1,
+            "name": "Affymetrix GeneChip Human Genome U133 Plus 2.0 [HG-U133_Plus_2]",
+            "accession": "A-AFFY-44",
+            "id": 11119
+          }
+        ],
+        "samplecharacteristic": [
+          {
+            "value": [
+              "Homo sapiens"
+            ],
+            "category": "Organism"
+          },
+          {
+            "value": [
+              "Human umbilical vein endothelial cell"
+            ],
+            "category": "tissue"
+          }
+        ],
+        "provider": [
+          {
+            "email": null,
+            "role": null,
+            "contact": "Steven Krilis"
+          },
+          {
+            "email": null,
+            "role": null,
+            "contact": "Pei Yu"
+          },
+          {
+            "email": "j.ioannou@ich.ucl.ac.uk",
+            "role": "submitter",
+            "contact": "Yiannis Ioannou"
+          }
+        ],
+        "description": [
+          {
+            "text": "The original text was too long. This is a placeholder.",
+            "id": null
+          }
+        ],
+        "experimenttype": [
+          "transcription profiling by array"
+        ],
+        "organism": [
+          "Homo sapiens"
+        ],
+        "lastupdatedate": "2011-06-10",
+        "submissiondate": "2010-06-03",
+        "releasedate": "2010-06-16",
+        "name": "Oxidoreductase transcript data from human umbilical vein endothelial cells",
+        "secondaryaccession": [
+          "GSE22166"
+        ],
+        "accession": "E-GEOD-22166",
+        "id": 16991
+      }
+    ],
+    "total-assays": 1,
+    "total-samples": 1,
+    "total": 1,
+    "revision": "091015",
+    "version": 3.0,
+    "api-revision": "091015",
+    "api-version": 3
+  }
+} """
+
+SAMPLES_JSON = """
+{
+  "experiment": {
+    "sample": [
+      {
+        "source": {
+          "comment": [
+            {
+              "value": "Gene expression data from embryos younger than nuclear cycle 9, i.e. before zygotic genome activation.",
+              "name": "Sample_description"
+            },
+            {
+              "value": "Unstimulated HUVEC",
+              "name": "Sample_source_name"
+            }
+          ],
+          "name": "GSM551183 1"
+        },
+        "scan": {
+          "name": "GSM551183.CEL"
+        },
+        "labeled-extract": {
+          "label": "biotin",
+          "name": "GSM551183 LE 1"
+        },
+        "file": [
+          {
+            "comment": {
+              "value": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.raw.1.zip",
+              "name": "ArrayExpress FTP file"
+            },
+            "url": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.raw.1.zip/GSM551183.CEL",
+            "name": "GSM551183.CEL",
+            "type": "data"
+          },
+          {
+            "comment": {
+              "value": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.processed.1.zip",
+              "name": "Derived ArrayExpress FTP file"
+            },
+            "url": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.processed.1.zip/GSM551183_sample_table.txt",
+            "name": "GSM551183_sample_table.txt",
+            "type": "derived data matrix"
+          }
+        ],
+        "extract": {
+          "name": "GSM551183 extract 1"
+        },
+        "characteristic": [
+          {
+            "value": "Homo sapiens",
+            "category": "Organism"
+          },
+          {
+            "value": "Human umbilical vein endothelial cell",
+            "category": "tissue"
+          }
+        ],
+        "assay": {
+          "name": "GSM551183"
+        }
+      }
+    ],
+    "accession": "E-GEOD-22166",
+    "revision": "091015",
+    "version": 1.0,
+    "api-revision": "091015",
+    "api-version": 3
+  }
+} """
+
+
+def mocked_requests_get(url):
+    mock = Mock(ok=True)
+    if url == (EXPERIMENTS_URL + "E-GEOD-22166"):
+        mock.json.return_value = json.loads(EXPERIMENTS_JSON)
+    else:
+        mock.json.return_value = json.loads(SAMPLES_JSON)
+
+    return mock
 
 
 def wait_for_job(job, job_class: type):
@@ -31,8 +257,16 @@ def wait_for_job(job, job_class: type):
 
 
 class ScanUpcEndToEndTestCase(TransactionTestCase):
-    def test_calls_survey(self):
+    @patch('data_refinery_foreman.surveyor.array_express.requests.get')
+    def test_calls_survey(self, mock_get):
         """If source_type is supported calls the appropriate survey method."""
+        mock_get.side_effect = mocked_requests_get
+
+        # Prevent a call being made to NCBI's API to determine
+        # organism name/id.
+        organism = Organism(name="HOMO SAPIENS", taxonomy_id=9606, is_scientific_name=True)
+        organism.save()
+
         survey_job = SurveyJob(source_type="ARRAY_EXPRESS")
         survey_job.save()
         key_value_pair = SurveyJobKeyValue(survey_job=survey_job,

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -190,7 +190,7 @@ SAMPLES_JSON = """
         "file": [
           {
             "comment": {
-              "value": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.raw.1.zip",
+              "value": "http://nginx/E-GEOD-22166.raw.1.zip",
               "name": "ArrayExpress FTP file"
             },
             "url": "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-22166/E-GEOD-22166.raw.1.zip/GSM551183.CEL",

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -1,0 +1,65 @@
+import time
+from django.test import TestCase
+from data_refinery_models.models import (
+    SurveyJob,
+    SurveyJobKeyValue,
+    Batch,
+    DownloaderJob,
+    ProcessorJob
+)
+from data_refinery_foreman.surveyor import surveyor
+
+from django.db import connection
+from pprint import pformat
+
+# Import and set logger
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+LOOP_TIME = 5  # seconds
+
+
+def wait_for_job(job, job_class: type):
+    """Monitors the `job_class` table for when `job` is done."""
+    job = job_class.objects.filter(id=job.id).get()
+    while job.success is None:
+        logger.info("Still polling the survey job.")
+        time.sleep(LOOP_TIME)
+        job = job_class.objects.filter(id=job.id).get()
+
+    return job
+
+
+class ScanUpcEndToEndTestCase(TestCase):
+    def test_calls_survey(self):
+        """If source_type is supported calls the appropriate survey method."""
+        logger.info(pformat(connection.settings_dict))
+
+        survey_job = SurveyJob(source_type="ARRAY_EXPRESS")
+        survey_job.save()
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                           key="experiment_accession_code",
+                                           value="E-GEOD-22166")
+        key_value_pair.save()
+
+        surveyor.run_job(survey_job)
+        logger.info("Started Survey Job %s, waiting for it to complete.", survey_job.id)
+        survey_job = wait_for_job(survey_job, SurveyJob)
+        self.assertTrue(survey_job.success)
+
+        batch = Batch.objects.all()[0]
+        batch = Batch.objects.filter(survey_job=survey_job).get()
+
+        downloader_job = batch.downloaderjob_set.get()
+        logger.info("Survey Job finished, waiting for Downloader Job %d to complete.",
+                    downloader_job.id)
+        downloader_job = wait_for_job(downloader_job, DownloaderJob)
+        self.assertTrue(downloader_job.success)
+
+        processor_job = batch.processorjob_set.get()
+        logger.info("Downloader Job finished, waiting for processor Job %d to complete.",
+                    processor_job.id)
+        processor_job = wait_for_job(processor_job, ProcessorJob)
+        self.assertTrue(processor_job.success)

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -9,9 +9,6 @@ from data_refinery_models.models import (
 )
 from data_refinery_foreman.surveyor import surveyor
 
-from django.db import connection
-from pprint import pformat
-
 # Import and set logger
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -36,8 +33,6 @@ def wait_for_job(job, job_class: type):
 class ScanUpcEndToEndTestCase(TransactionTestCase):
     def test_calls_survey(self):
         """If source_type is supported calls the appropriate survey method."""
-        logger.info(pformat(connection.settings_dict))
-
         survey_job = SurveyJob(source_type="ARRAY_EXPRESS")
         survey_job.save()
         key_value_pair = SurveyJobKeyValue(survey_job=survey_job,

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -1,5 +1,5 @@
 import time
-from django.test import TestCase
+from django.test import TransactionTestCase
 from data_refinery_models.models import (
     SurveyJob,
     SurveyJobKeyValue,
@@ -25,14 +25,15 @@ def wait_for_job(job, job_class: type):
     """Monitors the `job_class` table for when `job` is done."""
     job = job_class.objects.filter(id=job.id).get()
     while job.success is None:
-        logger.info("Still polling the survey job.")
+        logger.info("Still polling the %s.",
+                    job_class.__name__)
         time.sleep(LOOP_TIME)
         job = job_class.objects.filter(id=job.id).get()
 
     return job
 
 
-class ScanUpcEndToEndTestCase(TestCase):
+class ScanUpcEndToEndTestCase(TransactionTestCase):
     def test_calls_survey(self):
         """If source_type is supported calls the appropriate survey method."""
         logger.info(pformat(connection.settings_dict))

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -256,6 +256,9 @@ def wait_for_job(job, job_class: type):
     return job
 
 
+# TransactionTestCase makes database calls complete before the test
+# ends.  Otherwise the workers wouldn't actually be able to find the
+# job in the database cause it'd be stuck in a transaction.
 class ScanUpcEndToEndTestCase(TransactionTestCase):
     @patch('data_refinery_foreman.surveyor.array_express.requests.get')
     def test_calls_survey(self, mock_get):

--- a/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
+++ b/foreman/data_refinery_foreman/surveyor/end_to_end_tests.py
@@ -170,7 +170,7 @@ SAMPLES_JSON = """
         "source": {
           "comment": [
             {
-              "value": "Gene expression data from embryos younger than nuclear cycle 9, i.e. before zygotic genome activation.",
+              "value": "Gene expression data from embryos younger than.... truncated",
               "name": "Sample_description"
             },
             {
@@ -275,7 +275,7 @@ class ScanUpcEndToEndTestCase(TransactionTestCase):
         key_value_pair.save()
 
         surveyor.run_job(survey_job)
-        logger.info("Started Survey Job %s, waiting for it to complete.", survey_job.id)
+        logger.info("Started Survey Job %d, waiting for it to complete.", survey_job.id)
         survey_job = wait_for_job(survey_job, SurveyJob)
         self.assertTrue(survey_job.success)
 

--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -100,7 +100,7 @@ class ExternalSourceSurveyor:
                     downloader_job.delete()
                     raise
             else:
-                logger.info("Survey job #% found no new Batches.",
+                logger.info("Survey job #%d found no new Batches.",
                             self.survey_job.id)
 
         try:

--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -81,12 +81,14 @@ class ExternalSourceSurveyor:
             new_batches.append(batch)
 
         @retry(stop_max_attempt_number=3)
-        @transaction.atomic
         def save_batches_start_job():
             if len(new_batches) > 0:
                 downloader_task = self.downloader_task()
-                downloader_job = DownloaderJob.create_job_and_relationships(
-                    batches=new_batches, downloader_task=downloader_task)
+
+                with transaction.atomic():
+                    downloader_job = DownloaderJob.create_job_and_relationships(
+                        batches=new_batches, downloader_task=downloader_task)
+
                 logger.info("Survey job #%d is queuing downloader job #%d.",
                             self.survey_job.id,
                             downloader_job.id)

--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -92,7 +92,13 @@ class ExternalSourceSurveyor:
                 logger.info("Survey job #%d is queuing downloader job #%d.",
                             self.survey_job.id,
                             downloader_job.id)
-                app.send_task(downloader_task, args=[downloader_job.id])
+                try:
+                    app.send_task(downloader_task, args=[downloader_job.id])
+                except:
+                    # If the task doesn't get sent we don't want the
+                    # downloader_job to be left floating
+                    downloader_job.delete()
+                    raise
             else:
                 logger.info("Survey job #% found no new Batches.",
                             self.survey_job.id)

--- a/foreman/run_tests.sh
+++ b/foreman/run_tests.sh
@@ -16,6 +16,7 @@ docker build -t dr_foreman -f foreman/Dockerfile .
 HOST_IP=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
 
 docker run \
+       --link message-queue:rabbit \
        --add-host=database:$HOST_IP \
        --env-file foreman/environments/test \
        -i dr_foreman test --no-input "$@"

--- a/run_compose.sh
+++ b/run_compose.sh
@@ -1,0 +1,13 @@
+# This script should always run as if it were being called from
+# the directory it lives in.
+script_directory=`dirname "${BASH_SOURCE[0]}"  | xargs realpath`
+cd $script_directory
+
+export VOLUME_DIRECTORY="$script_directory/workers/volume"
+export HOST_IP=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
+
+export EXPERIMENT_LIST=single-assay-experiment.txt
+
+docker-compose build
+
+docker-compose up

--- a/run_compose.sh
+++ b/run_compose.sh
@@ -4,6 +4,7 @@ script_directory=`dirname "${BASH_SOURCE[0]}"  | xargs realpath`
 cd $script_directory
 
 export VOLUME_DIRECTORY="$script_directory/workers/volume"
+export STATIC_DIRECTORY="$script_directory/end_to_end_tests"
 export HOST_IP=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
 
 export EXPERIMENT_LIST=single-assay-experiment.txt

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -107,7 +107,6 @@ def _run_scan_upc(job_context: Dict) -> Dict:
         job_context["success"] = False
         # Array Express processor jobs have only one batch per job.
         file_management.remove_temp_directory(job_context["batches"][0])
-        return job_context
 
     return job_context
 

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -105,10 +105,9 @@ def _run_scan_upc(job_context: Dict) -> Dict:
         logger.error(log_message, job_context["job_id"])
         job_context["job"].failure_reason = base_error_message
         job_context["success"] = False
-        return job_context
-    finally:
         # Array Express processor jobs have only one batch per job.
         file_management.remove_temp_directory(job_context["batches"][0])
+        return job_context
 
     return job_context
 

--- a/workers/data_refinery_workers/processors/test_array_express.py
+++ b/workers/data_refinery_workers/processors/test_array_express.py
@@ -171,7 +171,6 @@ class RunScanUPCTestCase(TestCase):
 
         # success is only populated by this function on an error
         self.assertFalse("success" in job_context)
-        self.assertTrue(mock_file_management.remove_temp_directory.called)
         self.assertTrue(os.path.isfile(output_file))
 
         # Clean up the processed file

--- a/workers/data_refinery_workers/processors/test_array_express.py
+++ b/workers/data_refinery_workers/processors/test_array_express.py
@@ -163,8 +163,7 @@ class RunScanUPCTestCase(TestCase):
                        "input_file": input_file,
                        "output_file": output_file}
 
-        # If this file already exists for any reason then we aren't
-        # actually testing that it is generated
+        # If output_file exists, remove it first.
         if os.path.isfile(output_file):
             os.remove(output_file)
 

--- a/workers/data_refinery_workers/processors/test_array_express.py
+++ b/workers/data_refinery_workers/processors/test_array_express.py
@@ -165,7 +165,8 @@ class RunScanUPCTestCase(TestCase):
 
         # If this file already exists for any reason then we aren't
         # actually testing that it is generated
-        self.assertFalse(os.path.isfile(output_file))
+        if os.path.isfile(output_file):
+            os.remove(output_file)
 
         job_context = array_express._run_scan_upc(job_context)
 

--- a/workers/environments/test
+++ b/workers/environments/test
@@ -1,7 +1,7 @@
 DJANGO_SECRET_KEY=THIS_IS_NOT_A_SECRET_DO_NOT_USE_IN_PROD
 DJANGO_DEBUG=True
 
-DATABASE_NAME=data_refinery
+DATABASE_NAME=test_data_refinery
 DATABASE_USER=data_refinery_user
 DATABASE_PASSWORD=data_refinery_password
 DATABASE_HOST=database


### PR DESCRIPTION
Adds end-to-end tests for the Data Refinery. These run separately from all the other tests, using Docker Compose. Docker Compose runs 4 containers:
 - Workers (in normal mode, but with an environment of `test`)
 - Foreman (run via the test-runner)
 - Rabbit
 - Nginx (used to download data from within the workers)

The Foreman runs a survey job, which discovers a batch, queues a downloader job, and then waits for it to finish so it can discover its processor job, then waits for the processor job to finish. The workers run the downloader and processor jobs. The Foreman tests then check that `SCAN.UPC` outputting a processed file. More in depth testing of the contents of that file are upcoming.

I tested this without an internet connection to be sure that no external requests were actually being made. This will keep the tests from being finicky.